### PR TITLE
removed version specification in the readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,7 @@ If you are looking to include Highstock, Justin Kuepper has made [highstock-rail
 
 Add the gem to the Gemfile
 
-    gem "highcharts-rails", "~> 3.0.0"
+    gem "highcharts-rails"
     # The gem version mirrors the included version of Highcharts
 
 ## Changes


### PR DESCRIPTION
The version specification in the `install` section in the gemfile referenced to an old version and was confusing, 

Specifying no version in the gemfile and just leaving the comment about the version mirroring should be sufficient. 

